### PR TITLE
Drag-n-drop resorting implemented

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
   <script type="text/x-handlebars" id="track-template">
-      <li id="{{trackId}}" class="track inactive" style="background-image: url({{artwork_url}})">
+      <li id="{{trackId}}" class="track inactive" style="background-image: url({{artwork_url}});">
           <div id="clear{{trackId}}" class="clear"></div>
           <div class="trackinfo">
               <h1>{{title}}</h1><h3>{{trackDuration}}</h3>
@@ -17,7 +17,6 @@
           </div>
       </li>
   </script>
-
     <div id="topnav">
       <span id="icon"></span>
       <input id="input" type="text" name="pastelink" placeholder="Paste link" onfocus="lightenBackground()" onblur="darkenBackground()">
@@ -36,11 +35,11 @@
       <span id="time"></span>
       <span id="nowplaying"><span id="art"></span><span id="playingtext"></span></span>
     </div>
-
-
+    
     <script src="sdk-3.0.0.js"></script>
     <script src="jquery-2.1.4.min.js"></script>
     <script src="handlebars-v4.0.2.js"></script>
+    <script src="jquery-ui.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -24,6 +24,8 @@ var playState = false;
 var currentTime = "0:00";
 var firstPlay = true;
 
+
+
 $(document).on('click', "#add", function(){
     addTrack();
 });
@@ -138,7 +140,51 @@ function addTrack() {
             $( "#input" ).val("");
             trackId++;
         }
+
     })
+}
+/* =====================
+ * DRAG-N-DROP RESORTING
+ * =====================
+ */
+// Debug
+function printQueue(){
+    console.log("Current track: ", currentTrack);
+    for(var i in queue){
+        console.log(queue[i].title, currentTrack);
+
+    }
+}
+
+// Make the queue sortable
+$(document).ready(function(){
+    $( "#queue" ).sortable();
+})
+
+// When the visual queue (i.e. the list) gets reordered, update the actual queue
+$("#queue").on("sortstop", function(event, ui){
+    reorderQueue();
+});
+
+// The list tells us the desired order of play: use the track titles as a comparator
+// in order to update the actual queue.
+// O(n^2), but the queues are generally small so it's not a cardinal sin
+function reorderQueue(){
+    var tmpQueue = [];
+
+    $('ul > li').each(function(){
+        for(var i in queue){
+            if($(this).find('h1').text() === queue[i].title){
+                tmpQueue.push(queue[i]);
+                // Fix the currentTrack pointer
+                if($(this).attr('class') != "track inactive"){
+                    currentTrack = tmpQueue.length-1;
+                }
+            }
+        }
+    });
+
+    queue = tmpQueue;
 }
 
 function playPause() {


### PR DESCRIPTION
Reordering the queue is now easily done via drag-n-drop. Currently working under the assumption that the queue contains unique elements.
